### PR TITLE
Swappable droids etc..

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -217,6 +217,8 @@
 
 #define isidcard(A) (istype(A, /obj/item/card/id))
 
+#define isdroid(A) (istype(A, /obj/vehicle/unmanned/droid))
+
 //Assemblies
 #define isassembly(O) (istype(O, /obj/item/assembly))
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -72,7 +72,7 @@
 		return FALSE
 	if(QDELETED(target))
 		return FALSE
-	if(!isitem(target) && !ishuman(target))	//only items and mobs can be flung.
+	if(!isitem(target) && !ishuman(target) && !isdroid(target))	//only items, droids, and mobs can be flung.
 		return FALSE
 	var/max_dist = 3 //the distance only goes to 3 now, since this is more of a utility then an attack.
 	if(!owner.line_of_sight(target, max_dist))
@@ -176,7 +176,7 @@
 		affected_tile.Shake(4, 4, 2 SECONDS)
 		for(var/i in affected_tile)
 			var/atom/movable/affected = i
-			if(!ishuman(affected) && !istype(affected, /obj/item))
+			if(!ishuman(affected) && !istype(affected, /obj/item) && !isdroid(affected))
 				affected.Shake(4, 4, 20)
 				continue
 			if(ishuman(affected)) //if they're human, they also should get knocked off their feet from the blast.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -382,6 +382,24 @@
 		if(!(L.status_flags & CANPUSH))
 			return
 
+	if(isdroid(A) && a_intent == INTENT_HELP)
+		var/obj/vehicle/unmanned/droid/deet = A
+		now_pushing = TRUE
+		var/oldloc = loc
+		var/oldLloc = deet.loc
+		var/src_passmob = (flags_pass & PASSMOB)
+		flags_pass |= PASSMOB
+		deet.density = FALSE
+
+		deet.Move(oldloc)
+		Move(oldLloc)
+
+		deet.density = TRUE
+		if(!src_passmob)
+			flags_pass &= ~PASSMOB
+		now_pushing = FALSE
+		return
+
 	if(ismovableatom(A))
 		if(isxeno(src) && ishuman(A))
 			var/mob/living/carbon/human/H = A

--- a/code/modules/vehicles/unmanned/unmanned_droid.dm
+++ b/code/modules/vehicles/unmanned/unmanned_droid.dm
@@ -5,6 +5,7 @@
 	move_delay = 2.8
 	max_integrity = 300
 	turret_pattern = PATTERN_DROID
+	undercarriage = FALSE
 	gunnoise = 'sound/weapons/guns/fire/laser.ogg'
 	spawn_equipped_type = /obj/item/uav_turret/droid
 

--- a/code/modules/vehicles/unmanned/unmanned_droid.dm
+++ b/code/modules/vehicles/unmanned/unmanned_droid.dm
@@ -4,7 +4,6 @@
 	icon_state = "droidcombat"
 	move_delay = 2.8
 	max_integrity = 300
-	anchored = TRUE // no wheels
 	turret_pattern = PATTERN_DROID
 	gunnoise = 'sound/weapons/guns/fire/laser.ogg'
 	spawn_equipped_type = /obj/item/uav_turret/droid

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -141,7 +141,7 @@
 	current_rounds = min(current_rounds + ammo.current_rounds, max_rounds)
 	playsound(loc, 'sound/weapons/guns/interact/smartgun_unload.ogg', 25, 1)
 	qdel(ammo)
-	
+
 /// Try to equip a turret on the vehicle
 /obj/vehicle/unmanned/proc/equip_turret(obj/item/I, mob/user)
 	if(turret_path)
@@ -229,10 +229,19 @@
 	max_rounds = 200
 	max_integrity = 500
 
+/obj/vehicle/unmanned/medium/CanAllowThrough(atom/movable/mover, turf/target)
+	. = ..()
+	if(istype(mover) && CHECK_BITFIELD(mover.flags_pass, PASSTABLE))
+		return TRUE
+
 /obj/vehicle/unmanned/heavy
 	name = "heavy unmanned vehicle"
 	icon_state = "heavy_uv"
 	move_delay = 3.5
 	max_rounds = 200
 	max_integrity = 700
-	anchored = TRUE
+
+/obj/vehicle/unmanned/heavy/CanAllowThrough(atom/movable/mover, turf/target)
+	. = ..()
+	if(istype(mover) && CHECK_BITFIELD(mover.flags_pass, PASSTABLE))
+		return TRUE

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -41,6 +41,8 @@
 	var/obj/item/uav_turret/spawn_equipped_type = null
 	/// If something is already controlling the vehicle
 	var/controlled = FALSE
+	/// If the UV has traditional vehicle parts and room underneath a small xeno could pass
+	var/undercarriage = TRUE
 	COOLDOWN_DECLARE(fire_cooldown)
 
 /obj/vehicle/unmanned/Initialize()
@@ -101,6 +103,11 @@
 		return equip_turret(I, user)
 	if(istype(I, /obj/item/ammo_magazine))
 		return reload_turret(I, user)
+
+/obj/vehicle/unmanned/CanAllowThrough(atom/movable/mover, turf/target)
+	. = ..()
+	if(undercarriage && istype(mover) && CHECK_BITFIELD(mover.flags_pass, PASSTABLE))
+		return TRUE
 
 ///Try to desequip the turret
 /obj/vehicle/unmanned/wrench_act(mob/living/user, obj/item/I)
@@ -229,19 +236,9 @@
 	max_rounds = 200
 	max_integrity = 500
 
-/obj/vehicle/unmanned/medium/CanAllowThrough(atom/movable/mover, turf/target)
-	. = ..()
-	if(istype(mover) && CHECK_BITFIELD(mover.flags_pass, PASSTABLE))
-		return TRUE
-
 /obj/vehicle/unmanned/heavy
 	name = "heavy unmanned vehicle"
 	icon_state = "heavy_uv"
 	move_delay = 3.5
 	max_rounds = 200
 	max_integrity = 700
-
-/obj/vehicle/unmanned/heavy/CanAllowThrough(atom/movable/mover, turf/target)
-	. = ..()
-	if(istype(mover) && CHECK_BITFIELD(mover.flags_pass, PASSTABLE))
-		return TRUE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Droids are subordinate to all others intents, the other UVs are no longer anchored and can be pushed around like the mobile things they are, runners can pass under medium/heavy like tables, and shrikes fling and force ability work on droids.

I'm sure there are other cases where xenos will have WTF moments when things just don't work on droids they would expect, but if crusher toss is any indication most abilities are pretty `/mob/living/` centric and you can't just add a check for droids also.